### PR TITLE
Using libraries and fixed WASM head

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Update="Humanizer.Core"                             Version="2.7.9" />
+    <PackageReference Update="Humanizer.Core"                             Version="2.8.26" />
     <PackageReference Update="Microsoft.Extensions.Logging.Console"       Version="1.1.1" />
     <PackageReference Update="Microsoft.Extensions.Logging.Filter"        Version="1.1.2" />
     <PackageReference Update="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.9" />
     <PackageReference Update="Newtonsoft.Json"                            Version="12.0.3" />
-    <PackageReference Update="ReactiveUI.Fody"                            Version="11.1.1" />
-    <PackageReference Update="ReactiveUI.Uno"                             Version="11.1.1" />
+    <PackageReference Update="ReactiveUI.Fody"                            Version="11.4.17" />
+    <PackageReference Update="ReactiveUI.Uno"                             Version="11.4.17" />
     <PackageReference Update="Uno.CodeGen"                                Version="1.32.0" />
-    <PackageReference Update="Uno.Core"                                   Version="1.29.0" />
-    <PackageReference Update="Uno.UI"                                     Version="2.0.528" />
+    <PackageReference Update="Uno.Core"                                   Version="2.0.0" />
+    <PackageReference Update="Uno.UI"                                     Version="2.4.4" />
+    <PackageReference Update="Uno.UI.RemoteControl"                       Version="2.4.4" />
     <PackageReference Update="Uno.UniversalImageLoader"                   Version="1.9.32" />
-    <PackageReference Update="Uno.Wasm.Bootstrap"                         Version="1.0.10" />
+    <PackageReference Update="Uno.Wasm.Bootstrap"                         Version="1.2.0" />
+    <PackageReference Update="Uno.Wasm.Bootstrap.DevServer"               Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/ToDo/ToDo.Droid/ToDo.Droid.csproj
+++ b/ToDo/ToDo.Droid/ToDo.Droid.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -92,6 +92,16 @@
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\values\Styles.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ToDo.Models\ToDo.Models.csproj">
+      <Project>{54cc3dea-d0f4-47fb-8e73-d1ca4468a183}</Project>
+      <Name>ToDo.Models</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ToDo.ViewModels\ToDo.ViewModels.csproj">
+      <Project>{ecb17859-8634-44a4-86e8-2541234a1d05}</Project>
+      <Name>ToDo.ViewModels</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="..\ToDo.Shared\ToDo.Shared.projitems" Label="Shared" Condition="Exists('..\ToDo.Shared\ToDo.Shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/ToDo/ToDo.Shared/ToDo.Shared.projitems
+++ b/ToDo/ToDo.Shared/ToDo.Shared.projitems
@@ -31,12 +31,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)..\..\ToDo.Models\State.cs" Link="Models\State.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)..\..\ToDo.Models\Todo.cs" Link="Models\Todo.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)..\..\ToDo.Models\IdBasedObject.cs" Link="Models\IdBasedObject.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)..\..\ToDo.Models\Platform.cs" Link="Models\Platform.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)..\..\ToDo.Models\Scheduling.cs" Link="Models\Scheduling.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)..\..\ToDo.ViewModels\MainPageVM.cs" Link="ViewModels\MainPageVM.cs" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)MainPage.xaml">

--- a/ToDo/ToDo.UWP/ToDo.UWP.csproj
+++ b/ToDo/ToDo.UWP/ToDo.UWP.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <ItemGroup>
@@ -117,6 +117,16 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Properties\Default.rd.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ToDo.Models\ToDo.Models.csproj">
+      <Project>{54cc3dea-d0f4-47fb-8e73-d1ca4468a183}</Project>
+      <Name>ToDo.Models</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\ToDo.ViewModels\ToDo.ViewModels.csproj">
+      <Project>{ecb17859-8634-44a4-86e8-2541234a1d05}</Project>
+      <Name>ToDo.ViewModels</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="..\ToDo.Shared\ToDo.Shared.projitems" Label="Shared" Condition="Exists('..\ToDo.Shared\ToDo.Shared.projitems')" />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/ToDo/ToDo.Wasm/LinkerConfig.xml
+++ b/ToDo/ToDo.Wasm/LinkerConfig.xml
@@ -1,5 +1,4 @@
 ﻿<linker>
-  <assembly fullname="ToDo.Wasm" />
   <assembly fullname="ToDo.Models" />
   <assembly fullname="ToDo.ViewModels" />
   <assembly fullname="Uno.UI" />

--- a/ToDo/ToDo.Wasm/LinkerConfig.xml
+++ b/ToDo/ToDo.Wasm/LinkerConfig.xml
@@ -1,9 +1,15 @@
 ﻿<linker>
   <assembly fullname="ToDo.Wasm" />
+  <assembly fullname="ToDo.Models" />
+  <assembly fullname="ToDo.ViewModels" />
   <assembly fullname="Uno.UI" />
+  <assembly fullname="Uno.UI.Wasm" />
+  <assembly fullname="ReactiveUI" />
+  <assembly fullname="ReactiveUI.Fody.Helpers" />
+  <assembly fullname="ReactiveUI.Uno" />
 
   <assembly fullname="System.Core">
-	<!-- This is required by JSon.NET and any expression.Compile caller -->
-	<type fullname="System.Linq.Expressions*" />
+    <!-- This is required by JSon.NET and any expression.Compile caller -->
+    <type fullname="System.Linq.Expressions*" />
   </assembly>
 </linker>

--- a/ToDo/ToDo.Wasm/ToDo.Wasm.csproj
+++ b/ToDo/ToDo.Wasm/ToDo.Wasm.csproj
@@ -45,8 +45,9 @@
     <PackageReference Include="ReactiveUI.Uno" />
     <PackageReference Include="Uno.CodeGen" />
     <PackageReference Include="Uno.UI" />
+    <PackageReference Include="Uno.UI.RemoteControl" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.Wasm.Bootstrap" />
-    <DotNetCliToolReference Include="Uno.Wasm.Bootstrap.Cli" Version="1.0.10" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\ToDo.Models\ToDo.Models.csproj" />

--- a/ToDo/ToDo.Wasm/ToDo.Wasm.csproj
+++ b/ToDo/ToDo.Wasm/ToDo.Wasm.csproj
@@ -48,5 +48,9 @@
     <PackageReference Include="Uno.Wasm.Bootstrap" />
     <DotNetCliToolReference Include="Uno.Wasm.Bootstrap.Cli" Version="1.0.10" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ToDo.Models\ToDo.Models.csproj" />
+    <ProjectReference Include="..\..\ToDo.ViewModels\ToDo.ViewModels.csproj" />
+  </ItemGroup>
   <Import Project="..\ToDo.Shared\ToDo.Shared.projitems" Label="Shared" Condition="Exists('..\ToDo.Shared\ToDo.Shared.projitems')" />
 </Project>

--- a/UnoWorkshop.sln
+++ b/UnoWorkshop.sln
@@ -39,6 +39,7 @@ Global
 		ToDo\ToDo.Shared\ToDo.Shared.projitems*{2cb31828-2cd3-4cfc-88a9-57917477d85d}*SharedItemsImports = 4
 		ToDo\ToDo.Shared\ToDo.Shared.projitems*{320b8ae6-0249-48ac-a796-81d8642baf8f}*SharedItemsImports = 4
 		ToDo\ToDo.Shared\ToDo.Shared.projitems*{6279c845-92f8-4333-ab99-3d213163593c}*SharedItemsImports = 13
+		ToDo\ToDo.Shared\ToDo.Shared.projitems*{804ecb3a-3acc-40e4-b7b7-3d0e545808af}*SharedItemsImports = 5
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Ad-Hoc|Any CPU = Ad-Hoc|Any CPU


### PR DESCRIPTION
This change updates to the latest Uno Platform bits and also fixes issues with the WASM head when using the model and view model libraries.